### PR TITLE
fix: [tip]タグでの詳細表示時に[tip_loadcsv]の指定テンプレートが無視される

### DIFF
--- a/tip/js/tip.js
+++ b/tip/js/tip.js
@@ -376,7 +376,6 @@ function tip(pm) {
   pm.clickse = pm.clickse || tip_conf.tip_clickse; //TIPのクリック音
   pm.enterse = pm.enterse || tip_conf.tip_enterse; //TIPにマウスカーソルが乗った時の音
   pm.leavese = pm.leavese || tip_conf.tip_leavese; //TIPからマウスカーソルが外れた時の音
-  pm.tip_html = pm.tip_html || tip_conf.tip_html;
   pm.nextend = pm.nextend || "";
 
   //データが見つからない場合
@@ -406,6 +405,8 @@ function tip(pm) {
 
     //keyがある時
   } else {
+    // タグの指定 > data上の指定 > 共通設定の優先順位で参照
+    pm.tip_html = pm.tip_html || data[0].tip_html || tip_conf.tip_html;
     //オブジェクト作成
     let data_obj = "{";
     data_obj += '"key":"' + pm.key + '",';


### PR DESCRIPTION
[tip]タグでTIP詳細を開く際に参照しているデータが、[tip]タグへの指定か、[plugin]タグの共通設定しか参照していないため、同タグから詳細を開くと[tip_loadcsv]でtip_htmlを指定しても無視されてしまう。